### PR TITLE
v0.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,58 @@ Sharp "Shopping Bag" symbol:
 <span class="material-symbols-sharp">shopping_bag</span>
 ```
 
+### Google Fonts
+
+The Roboto font family from [Google Fonts](https://fonts.google.com/) can be used on your website
+by setting the following in the "font.google-fonts" section of `site.toml`.
+
+```toml
+Roboto = true
+```
+
+The following is an example of using the Robot font family:
+
+```html
+<p class="font-['Roboto']">Hello, world!</p>
+```
+
+If the font family name contains spaces, the name must be enclosed in double quotes as follows:
+
+```toml
+"Noto Sans Japanese" = true
+```
+
+Also, when using it in an HTML template, spaces should be replaced with underscores.
+
+```html
+<p class="font-['Noto_Sans_Japanese']">こんにちは、世界！</p>
+```
+
+To select some font weights in order to reduce the size of font file, specify weights as an array
+instead of `true`.
+
+```toml
+"Noto Sans Japanese" = [400, 800]
+```
+
+The following example uses the Noto Sans Japanese font family with weight 800.
+
+```html
+<p class="font-['Noto_Sans_Japanese'] font-[800]">こんにちは、世界！</p>
+```
+
+To select font weights for each style, specify weights using the inline table as follows:
+
+```toml
+"Pathway Extreme" = { normal = [400, 800], italic = [400] }
+```
+
+The following example uses the italic Pathway Extreme font family with weight 400.
+
+```html
+<p class="font-['Pathway_Extreme'] italic font-[400]">Hello, world!</p>
+```
+
 ## Layouts
 
 ### What is a layout

--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ using the `<tg:prop>` element.
 ---
 layout = "common"
 title = "Greeting"
+year = "2023"
 ---
 <h1>Welcome!</h1>
 <div class="bg-green-300 p-4">

--- a/README.md
+++ b/README.md
@@ -841,7 +841,7 @@ URL.
 ### Material Symbols
 
 By setting the value of the `material-symbols` property to `true` in the "font" section of
-`sites.yml`, [Material Symbols](https://developers.google.com/fonts/docs/material_symbols)
+`sites.toml`, [Material Symbols](https://developers.google.com/fonts/docs/material_symbols)
 provided by Google will be available on your website.
 
 ```toml
@@ -2505,7 +2505,7 @@ will search for a value in the following order:
 
 1. the front matter of its wrapper if available
 2. the front matter of its layout if available
-3. `sites.yml` if available
+3. `sites.toml` if available
 
 For example, suppose that the value `"a"` is set to the custom property `data.x` in the front
 matter of a page as follows:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3739,7 +3739,7 @@
       }
     },
     "packages/tgweb": {
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "alpinejs": "^3.12.0",

--- a/packages/tgweb/CHANGELOG.md
+++ b/packages/tgweb/CHANGELOG.md
@@ -1,5 +1,25 @@
 # tgweb CHANGELOG
 
+## 0.4.5
+
+### New features
+
+* ddbc009 Make Google Fonts available
+
+### Spec changes
+
+* a3fbb48 Rename the property that specifies whether to use Google Material Symbols
+          from `font-material-symbols` to `font.material-symbols`
+
+### Bug fixes
+
+* 8518e93 Fix `sort_articles.mjs` so that articles without indexes go to the end of the queue
+* a111ec2 Fix `update_site_data.mjs` so that template.inserts field gets updated
+* ad02599 Fix `get_type.mjs` so that extname of templates are checked
+* dcf756b Fix `update_site_data.mjs` so that it updates deps of siteData.segments
+* 607273c Fix `update_site_data.mjs` so that the dependencies of all templates
+          are updated when the site.toml gets updated
+
 ## 0.4.4
 
 * 589f457 Introduce `tg:tram` utility

--- a/packages/tgweb/lib/server/install_fonts.mjs
+++ b/packages/tgweb/lib/server/install_fonts.mjs
@@ -2,7 +2,11 @@ import * as PATH from "path"
 import fs from "fs"
 
 const installFonts = (siteData, workingDir) => {
-  if (siteData.properties["font-material-symbols"] === true) {
+  const fontTable = siteData.properties.font
+
+  if (typeof fontTable !== "object") return
+
+  if (fontTable["material-symbols"] === true) {
     const packageDir = PATH.resolve(PATH.join(workingDir, "node_modules", "material-symbols"))
 
     const filenames = [

--- a/packages/tgweb/lib/tgweb/get_type.mjs
+++ b/packages/tgweb/lib/tgweb/get_type.mjs
@@ -3,14 +3,15 @@ import * as PATH from "path"
 const getType = path => {
   const dirname = PATH.dirname(path)
   const filename = PATH.basename(path)
+  const ext = PATH.extname(path)
   const shortDirname = dirname.split("/").slice(0, 2).join("/")
 
   if (filename === "_wrapper.html") return "wrapper"
-  else if (shortDirname === "src/segments") return "segment"
-  else if (shortDirname === "src/components") return "component"
-  else if (shortDirname === "src/layouts") return "layout"
-  else if (shortDirname === "src/articles") return "article"
-  else if (shortDirname === "src/pages") return "page"
+  else if (shortDirname === "src/segments" && ext === ".html") return "segment"
+  else if (shortDirname === "src/components" && ext === ".html") return "component"
+  else if (shortDirname === "src/layouts" && ext === ".html") return "layout"
+  else if (shortDirname === "src/articles" && ext === ".html") return "article"
+  else if (shortDirname === "src/pages" && ext === ".html") return "page"
   else if (filename === "site.toml") return "site.toml"
   else if (filename === "color_scheme.toml") return "color_scheme.toml"
   else return "unkown"

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -1055,7 +1055,8 @@ const renderHead = (documentProperties) => {
     })
   }
 
-  if (documentProperties["font-material-symbols"] === true) {
+  if (typeof documentProperties.font === "object" &&
+    documentProperties.font["material-symbols"] === true) {
     const doc = parseDocument("<link rel='stylesheet' href='/css/material-symbols/index.css'>")
     children.push(doc.children[0])
   }

--- a/packages/tgweb/lib/tgweb/sort_articles.mjs
+++ b/packages/tgweb/lib/tgweb/sort_articles.mjs
@@ -35,12 +35,12 @@ const sortArticles = (articles, orderBy) => {
           return 0
         }
         else {
-          return 1
+          return (direction === "asc" ? -1 : 1)
         }
       }
       else {
-        if (j !== undefined) return -1
-        else return 1
+        if (j !== undefined) return (direction === "asc" ? 1 : -1)
+        else return (direction === "asc" ? -1 : 1)
       }
     })
   }

--- a/packages/tgweb/lib/tgweb/update_site_data.mjs
+++ b/packages/tgweb/lib/tgweb/update_site_data.mjs
@@ -4,12 +4,14 @@ import { getSiteData } from "./get_site_data.mjs"
 import { setDependencies } from "./set_dependencies.mjs"
 import { setUrlProperty } from "./set_url_property.mjs"
 import { getTemplate } from "./get_template.mjs"
+import { updateDependencies } from "./update_dependencies.mjs"
 
 const updateSiteData = (siteData, path) => {
   const type = getType(path)
 
   if (type == "site.toml") {
     const newSiteData = getSiteData(process.cwd())
+    updateDependencies(newSiteData)
     siteData.properties = newSiteData.properties
     siteData.pages = newSiteData.pages
     siteData.segments = newSiteData.segments

--- a/packages/tgweb/lib/tgweb/update_site_data.mjs
+++ b/packages/tgweb/lib/tgweb/update_site_data.mjs
@@ -66,6 +66,7 @@ const updateSiteData = (siteData, path) => {
       siteData.articles.push(newArticle)
 
       siteData.pages.forEach(p => setDependencies(p, siteData))
+      siteData.segments.forEach(s => setDependencies(s, siteData))
 
       siteData.articles.forEach(a => {
         if (`src/${a.path}` !== path) setDependencies(a, siteData)

--- a/packages/tgweb/lib/tgweb/update_site_data.mjs
+++ b/packages/tgweb/lib/tgweb/update_site_data.mjs
@@ -137,6 +137,7 @@ const updateSiteData = (siteData, path) => {
 const updateTemplate = (template, path) => {
   const newTemplate = getTemplate(path, undefined)
   template.frontMatter = newTemplate.frontMatter
+  template.inserts = newTemplate.inserts
   template.dom = newTemplate.dom
 }
 

--- a/packages/tgweb/package.json
+++ b/packages/tgweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgweb",
   "type": "module",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "keywords": [
     "teamgenik",
     "blog",


### PR DESCRIPTION
### New features

* ddbc009 Make Google Fonts available

### Spec changes

* a3fbb48 Rename the property that specifies whether to use Google Material Symbols
          from `font-material-symbols` to `font.material-symbols`

### Bug fixes

* 8518e93 Fix `sort_articles.mjs` so that articles without indexes go to the end of the queue
* a111ec2 Fix `update_site_data.mjs` so that template.inserts field gets updated
* ad02599 Fix `get_type.mjs` so that extname of templates are checked
* dcf756b Fix `update_site_data.mjs` so that it updates deps of siteData.segments
* 607273c Fix `update_site_data.mjs` so that the dependencies of all templates
          are updated when the site.toml gets updated
