### PR TITLE
v0.4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2310,9 +2310,9 @@ allows the user to control the state of the carousel.
 
 #### Carousel auto-rotation and animation effect
 
-To automatically rotate the carousel items at regular time intervals, specify the
-`tg:interval` attribute for the carousel.
-The numeric sequence specified in this attribute is interpreted as time in milliseconds.
+To automatically rotate the carousel items at regular time intervals, specify a positive integer
+for the `tg:interval` attribute of the carousel.
+The value specified in this attribute is interpreted as time in milliseconds.
 
 ```html
 <div tg:carousel tg:interval="3000">

--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,7 +3747,7 @@
       }
     },
     "packages/tgweb": {
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/container-queries": "^0.1.1",

--- a/packages/tgweb/CHANGELOG.md
+++ b/packages/tgweb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # tgweb CHANGELOG
 
+## 0.4.8
+
+* 9b2545e Fix a bug where the carousel does not work when the `tg:interval` attribute is not
+          specified for the carousel
+
 ## 0.4.7
 
 * 38c9dc8 Add `@tailwindcss/container-queries` to `package.json`

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -792,10 +792,13 @@ const addCarouselHook = (newNode, newState) => {
   newNode.attribs["x-data"] = "window.tgweb.carousel.data()"
   newState.hookName = "carousel"
 
-  if (newNode.attribs["tg:interval"] === undefined) return;
+  let interval = 0
 
-  const interval = parseInt(newNode.attribs["tg:interval"], 10)
-  if (Number.isNaN(interval)) return
+  if (newNode.attribs["tg:interval"] !== undefined) {
+    interval = parseInt(newNode.attribs["tg:interval"], 10)
+    if (Number.isNaN(interval)) interval = 0
+    if (interval < 0) interval = 0
+  }
 
   let duration = parseInt(newNode.attribs["tg:duration"], 10)
   if (Number.isNaN(duration)) duration = 100

--- a/packages/tgweb/package.json
+++ b/packages/tgweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgweb",
   "type": "module",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "keywords": [
     "teamgenik",
     "blog",

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -122,7 +122,8 @@ window.tgweb = {
         item.style.order = modulo(n - data.i + 2, data.len * data.repeatCount)
       })
 
-      data.v = setInterval(() => { window.tgweb.carousel._forward(data) }, interval)
+      if (interval > 0)
+        data.v = setInterval(() => { window.tgweb.carousel._forward(data) }, interval)
     },
     _forward: (data) => {
       window.tgweb.carousel._shiftPosition(data, "next")
@@ -134,7 +135,7 @@ window.tgweb = {
     },
     prev: (data) => {
       if (data.inTransition) return
-      clearInterval(data.v)
+      if (data.v) clearInterval(data.v)
       window.tgweb.carousel._shiftPosition(data, "prev")
 
       setTimeout(() => {
@@ -144,7 +145,7 @@ window.tgweb = {
     },
     next: (data) => {
       if (data.inTransition) return
-      clearInterval(data.v)
+      if (data.v) clearInterval(data.v)
       window.tgweb.carousel._shiftPosition(data, "next")
 
       setTimeout(() => {
@@ -153,7 +154,7 @@ window.tgweb = {
       }, data.duration + 250)
     },
     choose: (data, n) => {
-      clearInterval(data.v)
+      if (data.v) clearInterval(data.v)
 
       data.i = n
 


### PR DESCRIPTION
* 9b2545e Fix a bug where the carousel does not work when the `tg:interval` attribute is not specified for the carousel