### PR TITLE
v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2131,8 +2131,10 @@ to descendant elements of that element:
 * `tg:paginator`
 
 We call an HTML element with the `tg:switcher` attribute a _switcher_.
-There must be more than one element with the `tg:item` attribute in the switcher.
-We call them _switcher items_.
+
+Inside the switcher, there must always be an element with the `tg:body` attribute, a _switcher body_.
+In addition, there must be elements with the `tg:item` attribute, _switcher items_,
+inside the switcher body.
 
 Swticher items are assigned unique _index numbers_ starting from zero in sequence.
 A switcher has a state represented by an integer value, called an _current index number_.
@@ -2146,17 +2148,19 @@ Here is an example switcher:
 
 ```html
 <div tg:switcher>
-  <div tg:item>A</div>
-  <div tg:item>B</div>
-  <div tg:item>C</div>
-  <div tg:item>D</div>
-  <div tg:item>E</div>
+  <div tg:body>
+    <div tg:item>A</div>
+    <div tg:item>B</div>
+    <div tg:item>C</div>
+    <div tg:item>D</div>
+    <div tg:item>E</div>
+  </div>
   <nav>
-    <button type="button" tg:choose="1">a</button>
-    <button type="button" tg:choose="2">b</button>
-    <button type="button" tg:choose="3">c</button>
-    <button type="button" tg:choose="4">d</button>
-    <button type="button" tg:choose="5">e</button>
+    <button type="button" tg:choose="0">a</button>
+    <button type="button" tg:choose="1">b</button>
+    <button type="button" tg:choose="2">c</button>
+    <button type="button" tg:choose="3">d</button>
+    <button type="button" tg:choose="4">e</button>
   </nav>
 </div>
 ```
@@ -2170,7 +2174,7 @@ change the style applied to the button.
 ```html
   <button
     type="button"
-    tg:choose="1"
+    tg:choose="0"
     class="btn"
     tg:current-class="btn-primary cursor-default"
     tg:normal-class="btn-secondary">a</button>
@@ -2181,11 +2185,13 @@ You can create a button that change the state of the switcher using special attr
 
 ```html
 <div tg:switcher>
-  <div tg:item>A</div>
-  <div tg:item>B</div>
-  <div tg:item>C</div>
-  <div tg:item>D</div>
-  <div tg:item>E</div>
+  <div tg:body>
+    <div tg:item>A</div>
+    <div tg:item>B</div>
+    <div tg:item>C</div>
+    <div tg:item>D</div>
+    <div tg:item>E</div>
+  </div>
   <nav>
     <button type="button" tg:first>First</button>
     <button type="button" tg:prev>Prev</button>
@@ -2218,6 +2224,16 @@ by 1 at the specified interval (unit: millisecond).
 
 ```html
 <div tg:switcher tg:interval="2000">
+  ...
+</div>
+```
+
+If you want to add a fade-in/fade-out effect to the switcher, specify the time in milliseconds
+required for the fade-in or fade-out effect to complete in the `tg:transition-duration` attribute
+of the switcher.
+
+```html
+<div tg:switcher tg:interval="2000" tg:transition-duration="200">
   ...
 </div>
 ```
@@ -2450,7 +2466,7 @@ carousel items that are not currently displayed in the center of the carousel fr
 and class tokens specified in the `tg:current-class` attribute are applied to the button
 corresponding to the carousel item that is currently displayed in the center of the carousel frame.
 
-When the `tg:duration` attribute is set on the carousel, a user clicking/tapping the pagination
+When the `tg:transition-duration` attribute is set on the carousel, a user clicking/tapping the pagination
 buttons while the carousel body is shifting horizontally will have no effect.
 To visually indicate this, specify the `tg:disabled-class` attributes to
 the buttons.

--- a/README.md
+++ b/README.md
@@ -2359,10 +2359,10 @@ The value specified in this attribute is interpreted as time in milliseconds.
 ```
 
 If you want to add animation effect to the rotation of the carousel, specify the
-`tg:duration` attribute of the carousel.
+`tg:transition-duration` attribute of the carousel.
 
 ```html
-<div tg:carousel tg:interval="3000" tg:duration="500">
+<div tg:carousel tg:interval="3000" tg:transition-duration="500">
 ```
 
 By default, the horizontal movement of carousel items is linear, i.e., they move at the even speed.
@@ -2384,8 +2384,8 @@ The `ease-in-out` class moderates the movement near the beginning and near the e
 See [Transition Timing Function](https://tailwindcss.com/docs/transition-timing-function) for
 details.
 
-If the `tg:duration` attribute is set on the carousel, a user clicking/tapping the "prev" or
-"next" button while the carousel body is shifting horizontally will have no effect.
+If the `tg:transition-duration` attribute is set on the carousel, a user clicking/tapping the
+"prev" or "next" button while the carousel body is shifting horizontally will have no effect.
 To visually indicate this, specify the `tg:enabled-class` and `tg:disabled-class` attributes to
 the buttons.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,7 +3730,7 @@
       }
     },
     "packages/tgweb": {
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@ltd/j-toml": "^1.38.0",

--- a/packages/tgweb/CHANGELOG.md
+++ b/packages/tgweb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # tgweb CHANGELOG
 
+## 0.6.2
+
+* 4a74abb Add `window.onresize` to `tgweb_utilities.js` so that carousel body width is adjusted
+          automatically
+* 9c6f48a Fix `getLocalState`: copy `itemIndex` field value
+* 811de60 Fix `doRenderEmbeddedArticle`: copy `itemIndex` field value
+* 2d0a76d Fix switcher and rotator: find length of items on the JS side
+* 09d6712 Introduce `tg:transition-duration` attribute to switcher and rotator
+* 40ee889 Rename `tg:duration` attrbute of carousel to `tg:transition-duration`
+
 ## 0.6.1
 
 * f3790e3 Allow `<link>` elements with attributes other than `href` to be rendered (#93)

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -1127,15 +1127,15 @@ const postprocessCarousel = (node, newState) => {
     if (interval < 0) interval = 0
   }
 
-  let duration = parseInt(node.attribs["tg:duration"], 10)
-  if (Number.isNaN(duration)) duration = 0
+  let transitionDuration = parseInt(node.attribs["tg:transition-duration"], 10)
+  if (Number.isNaN(transitionDuration)) transitionDuration = 0
 
   const len = carouselItems.length
   newState.carouselItemCount = len
   newState.repeatCount = 3
 
   node.attribs["x-data"] =
-    `window.tgweb.carousel($el, ${len}, ${newState.repeatCount}, ${interval}, ${duration})`
+    `window.tgweb.carousel($el, ${len}, ${newState.repeatCount}, ${interval}, ${transitionDuration})`
 
   node.children = node.children.map(c => postprocess(c, newState)).flat()
   removeTgAttribs(node.attribs)

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -816,21 +816,18 @@ const addSwitcherHook = (node, newNode, newState) => {
   newState.hookName = "switcher"
   newState.itemIndex = 0
 
-  const items = DomUtils.findAll(elem => elem.attribs["tg:item"] !== undefined, node.children)
-  const len = items.length
-
   if (newNode.attribs["tg:interval"] !== undefined) {
     const interval = parseInt(newNode.attribs["tg:interval"], 10)
 
     if (! Number.isNaN(interval)) {
-      newNode.attribs["x-data"] = `window.tgweb.switcher(${len}, ${interval})`
+      newNode.attribs["x-data"] = `window.tgweb.switcher($el, ${interval})`
     }
     else {
-      newNode.attribs["x-data"] = `window.tgweb.switcher(${len})`
+      newNode.attribs["x-data"] = `window.tgweb.switcher($el)`
     }
   }
   else {
-    newNode.attribs["x-data"] = `window.tgweb.switcher(${len})`
+    newNode.attribs["x-data"] = `window.tgweb.switcher($el)`
   }
 }
 
@@ -882,21 +879,18 @@ const addRotatorHook = (node, newNode, newState) => {
   newState.hookName = "rotator"
   newState.itemIndex = 0
 
-  const items = DomUtils.findAll(elem => elem.attribs["tg:item"] !== undefined, node.children)
-  const len = items.length
-
   if (newNode.attribs["tg:interval"] !== undefined) {
     const interval = parseInt(newNode.attribs["tg:interval"], 10)
 
     if (! Number.isNaN(interval)) {
-      newNode.attribs["x-data"] = `window.tgweb.rotator(${len}, ${interval})`
+      newNode.attribs["x-data"] = `window.tgweb.rotator($el, ${interval})`
     }
     else {
-      newNode.attribs["x-data"] = `window.tgweb.rotator(${len})`
+      newNode.attribs["x-data"] = `window.tgweb.rotator($el`
     }
   }
   else {
-    newNode.attribs["x-data"] = `window.tgweb.rotator(${len})`
+    newNode.attribs["x-data"] = `window.tgweb.rotator($el`
   }
 }
 

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -816,18 +816,29 @@ const addSwitcherHook = (node, newNode, newState) => {
   newState.hookName = "switcher"
   newState.itemIndex = 0
 
-  if (newNode.attribs["tg:interval"] !== undefined) {
-    const interval = parseInt(newNode.attribs["tg:interval"], 10)
+  let interval
+  let transitionDuration
 
-    if (! Number.isNaN(interval)) {
-      newNode.attribs["x-data"] = `window.tgweb.switcher($el, ${interval})`
-    }
-    else {
-      newNode.attribs["x-data"] = `window.tgweb.switcher($el)`
-    }
+  if (newNode.attribs["tg:interval"] !== undefined) {
+    interval = parseInt(newNode.attribs["tg:interval"], 10)
+  }
+
+  if (newNode.attribs["tg:transition-duration"] !== undefined) {
+    transitionDuration = parseInt(newNode.attribs["tg:transition-duration"], 10)
+  }
+
+  if (! Number.isNaN(interval)) {
+    newNode.attribs["x-data"] = `window.tgweb.switcher($el, ${interval})`
   }
   else {
     newNode.attribs["x-data"] = `window.tgweb.switcher($el)`
+  }
+
+  if (! Number.isNaN(transitionDuration)) {
+    newState.transitionDuration = transitionDuration
+  }
+  else {
+    newState.transitionDuration = 0
   }
 }
 
@@ -837,9 +848,19 @@ const addSwitcherSubhooks = (newNode, state) => {
   const currentClass = (newNode.attribs["tg:current-class"] || "").replace(/'/, "\\'")
   const normalClass = (newNode.attribs["tg:normal-class"] || "").replace(/'/, "\\'")
 
-  if (newNode.attribs["tg:item"] !== undefined) {
-    newNode.attribs["data-index"] = String(state.itemIndex)
-    newNode.attribs["x-show"] = `$el.dataset.index === String(i)`
+  const commonStyle = `position: absolute; transition: opacity ${state.transitionDuration}ms`
+  const style0 = `opacity: 1; order: 0; ${commonStyle}`
+  const style1 = `opacity: 0; order: -1; ${commonStyle}`
+
+  if (newNode.attribs["tg:body"] !== undefined) {
+    newNode.attribs["data-switcher-body"] = ""
+  }
+  else if (newNode.attribs["tg:item"] !== undefined) {
+    newNode.attribs["data-item-index"] = String(state.itemIndex)
+
+    newNode.attribs["x-bind:style"] =
+      `$el.dataset.itemIndex === String(i) ? '${style0}' : '${style1}'`
+
     state.itemIndex = state.itemIndex + 1
   }
 
@@ -867,8 +888,8 @@ const addSwitcherSubhooks = (newNode, state) => {
     const n = parseInt(newNode.attribs["tg:choose"], 10)
 
     if (!Number.isNaN(n)) {
-      newNode.attribs["x-on:click"] = `choose(${n - 1})`
-      newNode.attribs["x-bind:class"] = `i == ${n - 1} ? '${currentClass}' : '${normalClass}'`
+      newNode.attribs["x-on:click"] = `choose(${n})`
+      newNode.attribs["x-bind:class"] = `i == ${n} ? '${currentClass}' : '${normalClass}'`
     }
   }
 }
@@ -879,31 +900,52 @@ const addRotatorHook = (node, newNode, newState) => {
   newState.hookName = "rotator"
   newState.itemIndex = 0
 
-  if (newNode.attribs["tg:interval"] !== undefined) {
-    const interval = parseInt(newNode.attribs["tg:interval"], 10)
+  let interval
+  let transitionDuration
 
-    if (! Number.isNaN(interval)) {
-      newNode.attribs["x-data"] = `window.tgweb.rotator($el, ${interval})`
-    }
-    else {
-      newNode.attribs["x-data"] = `window.tgweb.rotator($el`
-    }
+  if (newNode.attribs["tg:interval"] !== undefined) {
+    interval = parseInt(newNode.attribs["tg:interval"], 10)
+  }
+
+  if (newNode.attribs["tg:transition-duration"] !== undefined) {
+    transitionDuration = parseInt(newNode.attribs["tg:transition-duration"], 10)
+  }
+
+  if (! Number.isNaN(interval)) {
+    newNode.attribs["x-data"] = `window.tgweb.rotator($el, ${interval})`
   }
   else {
-    newNode.attribs["x-data"] = `window.tgweb.rotator($el`
+    newNode.attribs["x-data"] = `window.tgweb.rotator($el)`
+  }
+
+  if (! Number.isNaN(transitionDuration)) {
+    newState.transitionDuration = transitionDuration
+  }
+  else {
+    newState.transitionDuration = 0
   }
 }
 
-const addRotatorSubhooks = (newNode, newState) => {
+const addRotatorSubhooks = (newNode, state) => {
   const enebledClass = (newNode.attribs["tg:enabled-class"] || "").replace(/'/, "\\'")
   const disabledClass = (newNode.attribs["tg:disabled-class"] || "").replace(/'/, "\\'")
   const currentClass = (newNode.attribs["tg:current-class"] || "").replace(/'/, "\\'")
   const normalClass = (newNode.attribs["tg:normal-class"] || "").replace(/'/, "\\'")
 
-  if (newNode.attribs["tg:item"] !== undefined) {
-    newNode.attribs["data-index"] = String(newState.itemIndex)
-    newNode.attribs["x-show"] = `$el.dataset.index === String(i)`
-    newState.itemIndex = newState.itemIndex + 1
+  const commonStyle = `position: absolute; transition: opacity ${state.transitionDuration}ms`
+  const style0 = `opacity: 1; order: 0; ${commonStyle}`
+  const style1 = `opacity: 0; order: -1; ${commonStyle}`
+
+  if (newNode.attribs["tg:body"] !== undefined) {
+    newNode.attribs["data-rotator-body"] = ""
+  }
+  else if (newNode.attribs["tg:item"] !== undefined) {
+    newNode.attribs["data-item-index"] = String(state.itemIndex)
+
+    newNode.attribs["x-bind:style"] =
+      `$el.dataset.itemIndex === String(i) ? '${style0}' : '${style1}'`
+
+    state.itemIndex = state.itemIndex + 1
   }
 
   if (newNode.attribs["tg:first"] !== undefined) {
@@ -1346,6 +1388,7 @@ const getLocalState = (state, container, innerContent, inserts) => {
   newState.inserts = inserts || {}
   newState.hookName = state.hookName
   newState.itemIndex = state.itemIndex
+  newState.transitionDuration = state.transitionDuration
 
   if (state.referencedComponentNames !== undefined)
     newState.referencedComponentNames = [...state.referencedComponentNames]
@@ -1374,6 +1417,7 @@ const mergeState = (obj1, obj2) => {
   newState.inserts = obj1.inserts
   newState.hookName = obj1.hookName
   newState.itemIndex = obj1.itemIndex
+  newState.transitionDuration = obj1.transitionDuration
 
   if (obj1.referencedComponentNames !== undefined)
     newState.referencedComponentNames = [...obj1.referencedComponentNames]
@@ -1388,6 +1432,7 @@ const mergeState = (obj1, obj2) => {
   if (obj2.inserts !== undefined) newState.inserts = obj2.inserts
   if (obj2.hookName !== undefined) newState.hookName = obj2.hookName
   if (obj2.itemIndex !== undefined) newState.itemIndex = obj2.itemIndex
+  if (obj2.transitionDuration !== undefined) newState.transitionDuration = obj2.transitionDuration
 
   if (obj2.referencedComponentNames !== undefined)
     newState.referencedComponentNames = [...obj2.referencedComponentNames]

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -1344,6 +1344,7 @@ const getLocalState = (state, container, innerContent, inserts) => {
   newState.innerContent = innerContent
   newState.inserts = inserts || {}
   newState.hookName = state.hookName
+  newState.itemIndex = state.itemIndex
 
   if (state.referencedComponentNames !== undefined)
     newState.referencedComponentNames = [...state.referencedComponentNames]

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -497,12 +497,19 @@ const doRenderEmbeddedArticle = (article, parent, siteData, state) => {
       .map(child => renderNode(child, siteData, properties, localState))
       .flat()
 
+  state.itemIndex = localState.itemIndex
+
   if (wrapper) {
     const localState2 = getLocalState(state, wrapper, articleContent, article.inserts)
 
-    return wrapper.dom.children
-      .map(child => renderNode(child, siteData, properties, localState2))
-      .flat()
+    const content =
+      wrapper.dom.children
+        .map(child => renderNode(child, siteData, properties, localState2))
+        .flat()
+
+    state.itemIndex = localState2.itemIndex
+
+    return content
   }
   else {
     return articleContent

--- a/packages/tgweb/package.json
+++ b/packages/tgweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgweb",
   "type": "module",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "keywords": [
     "teamgenik",
     "blog",

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -80,12 +80,10 @@ window.tgweb = {
       clearInterval(this.v)
     },
     prev() {
-      console.log({i: this.i})
       this.i = this.i > 0 ? this.i - 1 : this.i
       clearInterval(this.v)
     },
     next() {
-      console.log({k: this.i, len})
       this.i = this.i < this.len - 1 ? this.i + 1 : this.i
       clearInterval(this.v)
     },

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -158,12 +158,12 @@ window.tgweb = {
       clearInterval(this.v)
     }
   }),
-  carousel: (el, len, repeatCount, interval, duration) => ({
+  carousel: (el, len, repeatCount, interval, transitionDuration) => ({
     el,
     len,
     repeatCount,
     interval,
-    duration,
+    transitionDuration,
     inTransition: false,
     i: 0,
     frame: undefined,
@@ -216,7 +216,7 @@ window.tgweb = {
       setTimeout(() => {
         this.i = this.i < this.len - 1 ? this.i + 1 : 0
         this._resetStyle()
-      }, this.duration + 250)
+      }, this.transitionDuration + 250)
     },
     prev() {
       if (this.inTransition) return
@@ -226,7 +226,7 @@ window.tgweb = {
       setTimeout(() => {
         this.i = this.i > 0 ? this.i - 1 : this.len - 1
         this._resetStyle()
-      }, this.duration + 250)
+      }, this.transitionDuration + 250)
     },
     next() {
       if (this.inTransition) return
@@ -236,7 +236,7 @@ window.tgweb = {
       setTimeout(() => {
         this.i = this.i < this.len - 1 ? this.i + 1 : 0
         this._resetStyle()
-      }, this.duration + 250)
+      }, this.transitionDuration + 250)
     },
     choose(n) {
       if (this.inTransition) return
@@ -248,11 +248,11 @@ window.tgweb = {
       setTimeout(() => {
         this.i = n
         this._resetStyle()
-      }, this.duration + 250)
+      }, this.transitionDuration + 250)
     },
     _shiftPosition(diff) {
       this.body.style.transitionProperty = "translate"
-      this.body.style.transitionDuration = this.duration + "ms"
+      this.body.style.transitionDuration = this.transitionDuration + "ms"
 
       const translateLength =
         this.itemWidth * (4 + diff) - (this.frame.offsetWidth - this.itemWidth) / 2

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -62,12 +62,15 @@ const withinRange = (progress, previousProgress, longDistance) => {
 }
 
 window.tgweb = {
-  switcher: (len, interval) => ({
-    len,
+  switcher: (el, interval) => ({
+    el,
     interval,
+    len: undefined,
     i: 0,
     v: undefined,
     init() {
+      this.len = this.el.querySelectorAll("[data-index]").length
+
       if (this.interval !== undefined) {
         this.v = setInterval(() => { this._forward() }, this.interval)
       }
@@ -96,12 +99,15 @@ window.tgweb = {
       clearInterval(this.v)
     }
   }),
-  rotator: (len, interval) => ({
-    len,
+  rotator: (el, interval) => ({
+    el,
     interval,
+    len: undefined,
     i: 0,
     v: undefined,
     init() {
+      this.len = this.el.querySelectorAll("[data-index]").length
+
       if (this.interval !== undefined) {
         this.v = setInterval(() => { this._forward() }, this.interval)
       }

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -172,6 +172,16 @@ window.tgweb = {
 
       this._resetStyle()
 
+      window.onresize = () => {
+        this.body.style.display = "block"
+        this.body.style.width = "auto"
+
+        this.itemWidth = firstItem.offsetWidth
+        this.body.style.display = "flex"
+        this.body.style.width = String(this.itemWidth * this.len * this.repeatCount) + "px"
+        this._resetStyle()
+      }
+
       if (this.interval > 0) this.v = setInterval(() => { this._forward() }, this.interval)
     },
     _forward() {

--- a/packages/tgweb/resources/tgweb_utilities.js
+++ b/packages/tgweb/resources/tgweb_utilities.js
@@ -69,7 +69,18 @@ window.tgweb = {
     i: 0,
     v: undefined,
     init() {
-      this.len = this.el.querySelectorAll("[data-index]").length
+      this.body = this.el.querySelector("[data-switcher-body]")
+
+      if (this.body === null) {
+        console.error("This switcher does not have body.")
+        return
+      }
+
+      this.body.style.display = "flex"
+      this.body.style.flexDirection = "column"
+      this.body.style.position = "relative"
+
+      this.len = this.el.querySelectorAll("[data-item-index]").length
 
       if (this.interval !== undefined) {
         this.v = setInterval(() => { this._forward() }, this.interval)
@@ -106,7 +117,18 @@ window.tgweb = {
     i: 0,
     v: undefined,
     init() {
-      this.len = this.el.querySelectorAll("[data-index]").length
+      this.body = this.el.querySelector("[data-rotator-body]")
+
+      if (this.body === null) {
+        console.error("This rotator does not have body.")
+        return
+      }
+
+      this.body.style.display = "flex"
+      this.body.style.flexDirection = "column"
+      this.body.style.position = "relative"
+
+      this.len = this.el.querySelectorAll("[data-item-index]").length
 
       if (this.interval !== undefined) {
         this.v = setInterval(() => { this._forward() }, this.interval)


### PR DESCRIPTION
* 4a74abb Add `window.onresize` to `tgweb_utilities.js` so that carousel body width is adjusted
          automatically
* 9c6f48a Fix `getLocalState`: copy `itemIndex` field value
* 811de60 Fix `doRenderEmbeddedArticle`: copy `itemIndex` field value
* 2d0a76d Fix switcher and rotator: find length of items on the JS side
* 09d6712 Introduce `tg:transition-duration` attribute to switcher and rotator
* 40ee889 Rename `tg:duration` attrbute of carousel to `tg:transition-duration`
