### PR TITLE
v0.8.3 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3984,7 +3984,7 @@
       }
     },
     "packages/tgweb": {
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@ltd/j-toml": "^1.38.0",

--- a/packages/tgweb/CHANGELOG.md
+++ b/packages/tgweb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # tgweb CHANGELOG
 
+## 0.8.3
+
+* 92e3699 Embed the value of the meta.name property etc. in `site.toml` into the values of other
+          properties.
+* 5645314 If an array is specified in the meta.name field of `site.toml`, generate `<meta>` tags
+          for that number of tags.
+
 ## 0.8.2
 
 * 97ac48a Fix tram's init() so that target.dataset.tramBaseClass gets initialized only once

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -1241,10 +1241,17 @@ const renderHead = (documentProperties) => {
       Object.keys(documentProperties.meta.name).forEach(name => {
         if (name.match(/"/) !== null) return
         const content = documentProperties.meta.name[name]
-        if (typeof content !== "string") return
 
-        const doc = parseDocument(`<meta name="${name}" content="${content}">`)
-        children.push(doc.children[0])
+        if (typeof content === "string") {
+          const doc = parseDocument(`<meta name="${name}" content="${content}">`)
+          children.push(doc.children[0])
+        }
+        else if (Array.isArray(content)) {
+          content.forEach(e => {
+            const doc = parseDocument(`<meta name="${name}" content="${e}">`)
+            children.push(doc.children[0])
+          })
+        }
       })
     }
 

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -1288,10 +1288,30 @@ const renderHead = (documentProperties) => {
           }
           else if (parts.length === 2) {
             const p1 = parts[0]
-            const p2 = parts[2]
+            const p2 = parts[1]
 
             if (typeof documentProperties.main[p1] === "object") {
               const value = documentProperties.main[p1][p2]
+
+              if (typeof value === "string") {
+                return value
+              }
+              else {
+                return `\${${propName}}`
+              }
+            }
+            else {
+              return `\${${propName}}`
+            }
+          }
+          else if (parts.length === 3) {
+            const p1 = parts[0]
+            const p2 = parts[1]
+            const p3 = parts[2]
+
+            if (typeof documentProperties[p1] === "object"
+              && typeof documentProperties[p1][p2] === "object") {
+              const value = documentProperties[p1][p2][p3]
 
               if (typeof value === "string") {
                 return value

--- a/packages/tgweb/package.json
+++ b/packages/tgweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgweb",
   "type": "module",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "keywords": [
     "teamgenik",
     "blog",

--- a/packages/tgweb/test/sites/minimum/src/site.toml
+++ b/packages/tgweb/test/sites/minimum/src/site.toml
@@ -1,2 +1,3 @@
 [meta.name]
 viewport = "width=device-width, initial-scale=1.0"
+googlebot = ["index,follow","notranslate"]

--- a/packages/tgweb/test/sites/minimum/src/site.toml
+++ b/packages/tgweb/test/sites/minimum/src/site.toml
@@ -1,3 +1,7 @@
 [meta.name]
 viewport = "width=device-width, initial-scale=1.0"
 googlebot = ["index,follow","notranslate"]
+description = "Description"
+
+[meta.property]
+"og:description" = "${meta.name.description}"

--- a/packages/tgweb/test/tgweb/create_initially.test.mjs
+++ b/packages/tgweb/test/tgweb/create_initially.test.mjs
@@ -29,6 +29,8 @@ describe("createInitially", () => {
       '    <meta charset="utf-8">',
       '    <title>Hello, world!</title>',
       '    <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+      '    <meta name="googlebot" content="index,follow">',
+      '    <meta name="googlebot" content="notranslate">',
       '    <link rel="stylesheet" href="/css/tailwind.css">',
       '    <style>',
       '      [x-cloak] {',

--- a/packages/tgweb/test/tgweb/create_initially.test.mjs
+++ b/packages/tgweb/test/tgweb/create_initially.test.mjs
@@ -31,6 +31,8 @@ describe("createInitially", () => {
       '    <meta name="viewport" content="width=device-width, initial-scale=1.0">',
       '    <meta name="googlebot" content="index,follow">',
       '    <meta name="googlebot" content="notranslate">',
+      '    <meta name="description" content="Description">',
+      '    <meta property="og:description" content="Description">',
       '    <link rel="stylesheet" href="/css/tailwind.css">',
       '    <style>',
       '      [x-cloak] {',

--- a/packages/tgweb/test/tgweb/render_web_page.test.mjs
+++ b/packages/tgweb/test/tgweb/render_web_page.test.mjs
@@ -32,6 +32,8 @@ describe("renderWebSite", () => {
       '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
       '  <meta name="googlebot" content="index,follow">',
       '  <meta name="googlebot" content="notranslate">',
+      '  <meta name="description" content="Description">',
+      '  <meta property="og:description" content="Description">',
       '  <link rel="stylesheet" href="/css/tailwind.css">',
       '  <style>',
       '    [x-cloak] {',

--- a/packages/tgweb/test/tgweb/render_web_page.test.mjs
+++ b/packages/tgweb/test/tgweb/render_web_page.test.mjs
@@ -30,6 +30,8 @@ describe("renderWebSite", () => {
       '  <meta charset="utf-8">',
       '  <title>Hello, world!</title>',
       '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+      '  <meta name="googlebot" content="index,follow">',
+      '  <meta name="googlebot" content="notranslate">',
       '  <link rel="stylesheet" href="/css/tailwind.css">',
       '  <style>',
       '    [x-cloak] {',


### PR DESCRIPTION
* 92e3699 Embed the value of the meta.name property etc. in `site.toml` into the values of other properties.
* 5645314 If an array is specified in the meta.name field of `site.toml`, generate `<meta>` tags for that number of tags.