### PR TITLE
v0.13.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/tgweb"
       ],
       "dependencies": {
-        "tgweb": "^0.13.1"
+        "tgweb": "^0.13.2"
       },
       "devDependencies": {
         "mocha": "^10.2.0"
@@ -4359,7 +4359,7 @@
       }
     },
     "packages/tgweb": {
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "MIT",
       "dependencies": {
         "@lottiefiles/dotlottie-web": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/tgweb"
   ],
   "dependencies": {
-    "tgweb": "^0.13.1"
+    "tgweb": "^0.13.2"
   },
   "devDependencies": {
     "mocha": "^10.2.0"

--- a/packages/tgweb/CHANGELOG.md
+++ b/packages/tgweb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tgweb CHANGELOG
 
+## 0.13.2
+
+* daf0a25 Exclude `reload.js` from HTML `<head>` generate by `npx tgweb-dist`
+
 ## 0.13.1
 
 * 2ec6728 Consider that there is a time lag between page initialization and tram initialization

--- a/packages/tgweb/lib/dist.mjs
+++ b/packages/tgweb/lib/dist.mjs
@@ -25,6 +25,7 @@ const main = (targetDirPath, options) => {
 
   const siteData = tgweb.getSiteData(process.cwd())
   siteData.options = options
+  siteData.forDistribution = true
 
   installFonts(siteData, workingDir)
   installUtilities(workingDir)

--- a/packages/tgweb/lib/tgweb/render_web_page.mjs
+++ b/packages/tgweb/lib/tgweb/render_web_page.mjs
@@ -108,7 +108,7 @@ const renderArticle = (path, siteData) => {
 
 const applyLayout = (page, layout, siteData, documentProperties, state) => {
   const doc = parseDocument("<html><head></head><body></body></html>")
-  const head = renderHead(documentProperties)
+  const head = renderHead(documentProperties, siteData.forDistribution)
 
   if (documentProperties.main["html-class"] !== undefined) {
     doc.children[0].attribs = {class: documentProperties.main["html-class"]}
@@ -141,7 +141,7 @@ const applyLayout = (page, layout, siteData, documentProperties, state) => {
 
 const applyWrapper = (page, wrapper, layout, siteData, documentProperties, state) => {
   const doc = parseDocument("<html><head></head><body></body></html>")
-  const head = renderHead(documentProperties)
+  const head = renderHead(documentProperties, siteData.forDistribution)
 
   if (documentProperties.main["html-class"] !== undefined) {
     doc.children[0].attribs = {class: documentProperties.main["html-class"]}
@@ -187,7 +187,7 @@ const applyWrapper = (page, wrapper, layout, siteData, documentProperties, state
 
 const doRenderPage = (page, siteData, documentProperties, state) => {
   const doc = parseDocument("<html><head></head><body></body></html>")
-  const head = renderHead(documentProperties)
+  const head = renderHead(documentProperties, siteData.forDistribution)
 
   if (documentProperties.main["html-class"] !== undefined) {
     doc.children[0].attribs = {class: documentProperties.main["html-class"]}
@@ -1435,7 +1435,7 @@ const removeTgAttribs = (attribs) => {
   keys.forEach(key => delete attribs[key])
 }
 
-const renderHead = (documentProperties) => {
+const renderHead = (documentProperties, forDistribution) => {
   const head = parseDocument("<head></head>")
 
   const children = []
@@ -1746,7 +1746,9 @@ const renderHead = (documentProperties) => {
   children.push(parseDocument("<script src='/js/tgweb_utilities.js' defer></script>").children[0])
   children.push(parseDocument("<script src='/js/alpine.min.js' defer></script>").children[0])
   children.push(parseDocument("<script type='module' src='/js/tgweb_lottie_player.js'></script>").children[0])
-  children.push(parseDocument("<script src='/reload/reload.js' defer></script>").children[0])
+
+  if (forDistribution !== true)
+    children.push(parseDocument("<script src='/reload/reload.js' defer></script>").children[0])
 
   if (typeof documentProperties.javascripts === "object") {
     for (const [key, value] of Object.entries(documentProperties.javascripts)) {

--- a/packages/tgweb/package.json
+++ b/packages/tgweb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tgweb",
   "type": "module",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "keywords": [
     "teamgenik",
     "blog",


### PR DESCRIPTION
* daf0a25 Exclude `reload.js` from HTML `<head>` generate by `npx tgweb-dist`